### PR TITLE
Update Makefrag-verilator

### DIFF
--- a/verisim/Makefrag-verilator
+++ b/verisim/Makefrag-verilator
@@ -1,5 +1,5 @@
 # Build and install our own Verilator, to work around versionining issues.
-VERILATOR_VERSION=3.904
+VERILATOR_VERSION=3.920
 VERILATOR_SRCDIR=verilator/src/verilator-$(VERILATOR_VERSION)
 INSTALLED_VERILATOR=$(abspath verilator/install/bin/verilator)
 $(INSTALLED_VERILATOR): $(VERILATOR_SRCDIR)/bin/verilator


### PR DESCRIPTION
Changed verilator version from 3.904 to 3.920, which fixes a bug that prevented the default example to compile correctly