### PR TITLE
Add an AXI4 flavor of PWM peripheral.

### DIFF
--- a/src/main/scala/example/Configs.scala
+++ b/src/main/scala/example/Configs.scala
@@ -26,7 +26,12 @@ class WithExampleTop extends Config((site, here, up) => {
 
 class WithPWM extends Config((site, here, up) => {
   case BuildTop => (clock: Clock, reset: Bool, p: Parameters) =>
-    Module(LazyModule(new ExampleTopWithPWM()(p)).module)
+    Module(LazyModule(new ExampleTopWithPWMTL()(p)).module)
+})
+
+class WithPWMAXI4 extends Config((site, here, up) => {
+  case BuildTop => (clock: Clock, reset: Bool, p: Parameters) =>
+    Module(LazyModule(new ExampleTopWithPWMAXI4()(p)).module)
 })
 
 class WithBlockDeviceModel extends Config((site, here, up) => {
@@ -56,6 +61,8 @@ class RoccExampleConfig extends Config(
   new WithRoccExample ++ new DefaultExampleConfig)
 
 class PWMConfig extends Config(new WithPWM ++ new BaseExampleConfig)
+
+class PWMAXI4Config extends Config(new WithPWMAXI4 ++ new BaseExampleConfig)
 
 class SimBlockDeviceConfig extends Config(
   new WithBlockDevice ++ new WithSimBlockDevice ++ new BaseExampleConfig)

--- a/src/main/scala/example/Top.scala
+++ b/src/main/scala/example/Top.scala
@@ -26,13 +26,21 @@ class ExampleTopModule[+L <: ExampleTop](l: L) extends RocketSubsystemModuleImp(
     with HasPeripherySerialModuleImp
     with DontTouch
 
-class ExampleTopWithPWM(implicit p: Parameters) extends ExampleTop
-    with HasPeripheryPWM {
-  override lazy val module = new ExampleTopWithPWMModule(this)
+class ExampleTopWithPWMTL(implicit p: Parameters) extends ExampleTop
+    with HasPeripheryPWMTL {
+  override lazy val module = new ExampleTopWithPWMTLModule(this)
 }
 
-class ExampleTopWithPWMModule(l: ExampleTopWithPWM)
-  extends ExampleTopModule(l) with HasPeripheryPWMModuleImp
+class ExampleTopWithPWMTLModule(l: ExampleTopWithPWMTL)
+  extends ExampleTopModule(l) with HasPeripheryPWMTLModuleImp
+
+class ExampleTopWithPWMAXI4(implicit p: Parameters) extends ExampleTop
+    with HasPeripheryPWMAXI4 {
+  override lazy val module = new ExampleTopWithPWMAXI4Module(this)
+}
+
+class ExampleTopWithPWMAXI4Module(l: ExampleTopWithPWMAXI4)
+  extends ExampleTopModule(l) with HasPeripheryPWMAXI4ModuleImp
 
 class ExampleTopWithBlockDevice(implicit p: Parameters) extends ExampleTop
     with HasPeripheryBlockDevice {


### PR DESCRIPTION
Also closes #41.

I'm using fixedWidth rather than variableWidth because it seems fragmenter doesn't interact well with the axi<->tl converter. Is there a cleaner way I should do this? @colinschmidt 