### PR TITLE
Update gitmodule url to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/ucb-bar/testchipip.git
 [submodule "barstools"]
 	path = barstools
-	url = git@github.com:ucb-bar/barstools
+	url = https://github.com/ucb-bar/barstools.git


### PR DESCRIPTION
The .git suffix was dropped and git@ was used instead of https://

Update to be consistent with other submodules.