### PR TITLE
Bumps barstools and fixes build system after

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -34,6 +34,8 @@ HARNESS_FILE ?=$(build_dir)/$(long_name).harness.v
 SMEMS_FILE   ?=$(build_dir)/$(long_name).mems.v
 SMEMS_CONF   ?=$(build_dir)/$(long_name).mems.conf
 sim_dotf ?= $(build_dir)/sim_files.f
+sim_harness_blackboxes ?= $(build_dir)/firrtl_black_box_resource_files.harness.f
+sim_top_blackboxes ?= $(build_dir)/firrtl_black_box_resource_files.top.f
 
 REPL_SEQ_MEM = --infer-rw --repl-seq-mem -c:$(MODEL):-o:$(SMEMS_CONF)
 
@@ -63,9 +65,11 @@ $(FIRRTL_FILE) $(ANNO_FILE): $(SCALA_SOURCES) $(sim_dotf)
 
 $(VERILOG_FILE) $(SMEMS_CONF): $(FIRRTL_FILE) $(ANNO_FILE) $(TAPEOUT_JAR)
 	$(TAPEOUT) barstools.tapeout.transforms.GenerateTop -o $(VERILOG_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(MODEL) -faf $(ANNO_FILE) $(REPL_SEQ_MEM) -td $(build_dir)
+	cp $(build_dir)/firrtl_black_box_resource_files.f $(sim_top_blackboxes)
 
-$(HARNESS_FILE): $(FIRRTL_FILE) $(ANNO_FILE) $(TAPEOUT_JAR)
+$(HARNESS_FILE): $(FIRRTL_FILE) $(ANNO_FILE) $(TAPEOUT_JAR) $(sim_top_blackboxes)
 	$(TAPEOUT) barstools.tapeout.transforms.GenerateHarness -o $(HARNESS_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(MODEL) -faf $(ANNO_FILE) -td $(build_dir)
+	grep -v "SimSerial.cc\|SimDTM.cc\|SimJTAG.cc" $(build_dir)/firrtl_black_box_resource_files.f > $(sim_harness_blackboxes)
 
 # This file is for simulation only. VLSI flows should replace this file with one containing hard SRAMs
 $(SMEMS_FILE): $(SMEMS_CONF) $(MACROCOMPILER_JAR)

--- a/src/main/scala/example/Simulator.scala
+++ b/src/main/scala/example/Simulator.scala
@@ -82,6 +82,7 @@ object GenerateSimFiles extends App with HasGenerateSimConfig {
     out.close()
   }
   def resources(sim: Simulator): Seq[String] = Seq(
+    "/testchipip/csrc/SimSerial.cc",
     "/csrc/SimDTM.cc",
     "/csrc/SimJTAG.cc",
     "/csrc/remote_bitbang.h",

--- a/verisim/Makefile
+++ b/verisim/Makefile
@@ -26,9 +26,6 @@ ifneq ($(filter run% %.run %.out %.vpd %.vcd,$(MAKECMDGOALS)),)
 -include $(build_dir)/$(long_name).d
 endif
 
-sim_blackboxes = \
-  $(build_dir)/firrtl_black_box_resource_files.f
-
 rocketchip_vsrc_dir = $(ROCKETCHIP_DIR)/src/main/resources/vsrc
 
 sim_vsrcs = \
@@ -49,7 +46,7 @@ $(model_mk): $(sim_vsrcs) $(sim_dotf) $(INSTALLED_VERILATOR)
 	rm -rf $(build_dir)/$(long_name)
 	mkdir -p $(build_dir)/$(long_name)
 	$(VERILATOR) $(VERILATOR_FLAGS) -Mdir $(build_dir)/$(long_name) \
-	-o $(sim) $(sim_vsrcs) -f $(sim_dotf) -f $(sim_blackboxes) -LDFLAGS "$(LDFLAGS)" \
+	-o $(sim) $(sim_vsrcs) -f $(sim_dotf) -f $(sim_top_blackboxes) -f $(sim_harness_blackboxes) -LDFLAGS "$(LDFLAGS)" \
 	-CFLAGS "-I$(build_dir) -include $(build_dir)/$(long_name).plusArgs -include $(model_header)"
 	touch $@
 
@@ -61,7 +58,7 @@ $(model_mk_debug): $(sim_vsrcs) $(sim_dotf) $(INSTALLED_VERILATOR)
 	rm -rf $(build_dir)/$(long_name)
 	mkdir -p $(build_dir)/$(long_name).debug
 	$(VERILATOR) $(VERILATOR_FLAGS) -Mdir $(build_dir)/$(long_name).debug --trace \
-	-o $(sim_debug) $(sim_vsrcs) -f $(sim_dotf) -f $(sim_blackboxes) -LDFLAGS "$(LDFLAGS)" \
+	-o $(sim_debug) $(sim_vsrcs) -f $(sim_dotf) -f $(sim_top_blackboxes) -f $(sim_harness_blackboxes) -LDFLAGS "$(LDFLAGS)" \
 	-CFLAGS "-I$(build_dir) -include $(build_dir)/$(long_name).plusArgs -include $(model_header_debug)"
 	touch $@
 

--- a/vsim/Makefile
+++ b/vsim/Makefile
@@ -22,8 +22,6 @@ ifneq ($(filter run% %.run %.out %.vpd %.vcd,$(MAKECMDGOALS)),)
 -include $(build_dir)/$(long_name).d
 endif
 
-sim_blackboxes = \
-  $(build_dir)/firrtl_black_box_resource_files.f
 
 rocketchip_vsrc_dir = $(ROCKETCHIP_DIR)/src/main/resources/vsrc
 
@@ -40,7 +38,7 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	-CC "-I$(RISCV)/include" \
 	-CC "-std=c++11" \
 	-CC "-Wl,-rpath,$(RISCV)/lib" \
-	-f $(sim_blackboxes) -f $(sim_dotf) \
+	-f $(sim_top_blackboxes) -f $(sim_harness_blackboxes) -f $(sim_dotf) \
 	$(RISCV)/lib/libfesvr.so \
 	-sverilog \
 	+incdir+$(generated_dir) \


### PR DESCRIPTION
Barstools now handles annotations correctly.
This means that the blackboxresources for the harness
and top are different and need to be merged in the build system.
We also add all Sim*.cc files to default resources as our new emulator
demands. We then remove them from the harness .f file to avoid having
to detect which ones to include selectively.