### PR TITLE
[rebar] fix make clean

### DIFF
--- a/sims/verisim/Makefile
+++ b/sims/verisim/Makefile
@@ -89,5 +89,5 @@ $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 # general cleanup rule
 #########################################################################################
 .PHONY: clean
-clean: clean-scala
+clean:
 	rm -rf $(build_dir) $(sim_prefix)-*

--- a/sims/vsim/Makefile
+++ b/sims/vsim/Makefile
@@ -93,5 +93,5 @@ $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 # general cleanup rule
 #########################################################################################
 .PHONY: clean
-clean: clean-scala
+clean:
 	rm -rf $(build_dir) csrc $(sim_prefix)-* ucli.key vc_hdrs.h


### PR DESCRIPTION
fix bug where `make clean` wouldn't run since I deleted the `clean-scala` target earlier