### PR TITLE
Improve VCS waves performance by using vlsi-mem-gen for SimAXIMem

### DIFF
--- a/sims/vsim/Makefile
+++ b/sims/vsim/Makefile
@@ -61,13 +61,14 @@ VCS_NONCC_OPTS = \
 	-sverilog \
 	+incdir+$(build_dir) \
 	+define+CLOCK_PERIOD=1.0 \
-    $(sim_vsrcs) \
+        $(sim_vsrcs) \
 	+define+PRINTF_COND=$(TB).printf_cond \
 	+define+STOP_COND=!$(TB).reset \
 	+define+RANDOMIZE_MEM_INIT \
 	+define+RANDOMIZE_REG_INIT \
 	+define+RANDOMIZE_GARBAGE_ASSIGN \
 	+define+RANDOMIZE_INVALID_ASSIGN \
+        +define+RANDOMIZE_DELAY=2 \
 	+libext+.v
 
 VCS_OPTS = -notice -line $(VCS_CC_OPTS) $(VCS_NONCC_OPTS)
@@ -94,4 +95,4 @@ $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 #########################################################################################
 .PHONY: clean
 clean:
-	rm -rf $(build_dir) csrc $(sim_prefix)-* ucli.key vc_hdrs.h
+	rm -rf generated-src/* csrc $(sim_prefix)-* ucli.key vc_hdrs.h

--- a/variables.mk
+++ b/variables.mk
@@ -56,7 +56,7 @@ ifeq ($(SUB_PROJECT),boom)
 	MODEL             ?= TestHarness
 	VLOG_MODEL        ?= TestHarness
 	MODEL_PACKAGE     ?= boom.system
-	CONFIG            ?= BoomConfig
+	CONFIG            ?= DefaultBoomConfig
 	CONFIG_PACKAGE    ?= boom.system
 	GENERATOR_PACKAGE ?= boom.system
 	TB                ?= TestDriver
@@ -107,20 +107,22 @@ ifeq ($(GENERATOR_PACKAGE),hwacha)
 	long_name=$(MODEL_PACKAGE).$(CONFIG)
 endif
 
-FIRRTL_FILE  ?= $(build_dir)/$(long_name).fir
-ANNO_FILE    ?= $(build_dir)/$(long_name).anno.json
-VERILOG_FILE ?= $(build_dir)/$(long_name).top.v
-TOP_FIR      ?= $(build_dir)/$(long_name).top.fir
-TOP_ANNO     ?= $(build_dir)/$(long_name).top.anno.json
-HARNESS_FILE ?= $(build_dir)/$(long_name).harness.v
-HARNESS_FIR  ?= $(build_dir)/$(long_name).harness.fir
-HARNESS_ANNO ?= $(build_dir)/$(long_name).harness.anno.json
-SMEMS_FILE   ?= $(build_dir)/$(long_name).mems.v
-SMEMS_CONF   ?= $(build_dir)/$(long_name).mems.conf
-SMEMS_FIR    ?= $(build_dir)/$(long_name).mems.fir
-sim_dotf     ?= $(build_dir)/sim_files.f
+FIRRTL_FILE        ?= $(build_dir)/$(long_name).fir
+ANNO_FILE          ?= $(build_dir)/$(long_name).anno.json
+VERILOG_FILE       ?= $(build_dir)/$(long_name).top.v
+TOP_FIR            ?= $(build_dir)/$(long_name).top.fir
+TOP_ANNO           ?= $(build_dir)/$(long_name).top.anno.json
+HARNESS_FILE       ?= $(build_dir)/$(long_name).harness.v
+HARNESS_FIR        ?= $(build_dir)/$(long_name).harness.fir
+HARNESS_ANNO       ?= $(build_dir)/$(long_name).harness.anno.json
+HARNESS_SMEMS_FILE ?= $(build_dir)/$(long_name).hmems.v
+HARNESS_SMEMS_CONF ?= $(build_dir)/$(long_name).hmems.conf
+SMEMS_FILE         ?= $(build_dir)/$(long_name).mems.v
+SMEMS_CONF         ?= $(build_dir)/$(long_name).mems.conf
+SMEMS_FIR          ?= $(build_dir)/$(long_name).mems.fir
+sim_dotf           ?= $(build_dir)/sim_files.f
 sim_harness_blackboxes ?= $(build_dir)/firrtl_black_box_resource_files.harness.f
-sim_top_blackboxes ?= $(build_dir)/firrtl_black_box_resource_files.top.f
+sim_top_blackboxes     ?= $(build_dir)/firrtl_black_box_resource_files.top.f
 
 #########################################################################################
 # default sbt launch command
@@ -151,7 +153,8 @@ rocketchip_vsrc_dir = $(ROCKETCHIP_DIR)/src/main/resources/vsrc
 sim_vsrcs = \
 	$(VERILOG_FILE) \
 	$(HARNESS_FILE) \
-	$(SMEMS_FILE)
+	$(SMEMS_FILE) \
+	$(HARNESS_SMEMS_FILE)
 
 #########################################################################################
 # assembly/benchmark variables


### PR DESCRIPTION
**Issue**:
Dumping the SimAXIMem to waves degrades VCS performance, incurs a ~30 second startup penalty to VCS simulations, and generates >800MB .vpds. Ideally, we would be able to specify a flag in VCS to not dump memories above a certain size, or annotate the memory in Chisel/Firrtl as DoNotCollectWaves. The first solution is impossible, and the second requires too much re-engineering.

However, the SimAXIMem is larger than the fixed VCS memory dump size limit when it is generated as a unified memory, rather than a banked memory.

For `name mem_ext depth 33554432 width 64 ports mwrite,read mask_gran 8`, we should emit

```
reg [63:0] ram [33554431:0];
```
vs
```
reg [7:0] ram [0:33554431];
reg [7:0] ram_1 [0:33554431];
reg [7:0] ram_2 [0:33554431];
reg [7:0] ram_3 [0:33554431];
reg [7:0] ram_4 [0:33554431];
reg [7:0] ram_5 [0:33554431];
reg [7:0] ram_6 [0:33554431];
reg [7:0] ram_7 [0:33554431];
```

When simulating the combined ram, VCS will decide that it is too large to dump, ignoring it. The simulation will then startup instantly and generate small waveforms (~30M).

**Solution**
There are two workarounds for this.

The first is to generate a larger SimAXIMem with the `WithExtMemSize` mixin. This is undesirable since we shouldn't have to mess with the config to get good simulation performance.

The second is to use `vlsi_mem_gen` in rocketchip, which correctly generates the combined memory.

This PR attempts the second approach. I understand that `vlsi_mem_gen` is deprecated in favor of macrocompiler, but it should be fine to use that script only for simulated TestHarness memories?

- [ ] PR and bump barstools, since it needs to support repl-seq-mem in the generateHarness phase.
- [ ] Verify verisim still works
