### PR TITLE
Run Binary Default Flag Change

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -86,10 +86,10 @@ $(output_dir)/%: $(RISCV)/riscv64-unknown-elf/share/riscv-tests/isa/%
 	ln -sf $< $@
 
 $(output_dir)/%.run: $(output_dir)/% $(sim)
-	$(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(PERMISSIVE_OFF) $< && touch $@
+	$(sim) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< && touch $@
 
 $(output_dir)/%.out: $(output_dir)/% $(sim)
-	$(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $@
+	$(sim) $(PERMISSIVE_ON) +verbose +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $@
 
 #########################################################################################
 # include build/project specific makefrags made from the generator

--- a/common.mk
+++ b/common.mk
@@ -86,10 +86,10 @@ $(output_dir)/%: $(RISCV)/riscv64-unknown-elf/share/riscv-tests/isa/%
 	ln -sf $< $@
 
 $(output_dir)/%.run: $(output_dir)/% $(sim)
-	$(sim) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< && touch $@
+	$(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(PERMISSIVE_OFF) $< && touch $@
 
 $(output_dir)/%.out: $(output_dir)/% $(sim)
-	$(sim) $(PERMISSIVE_ON) +verbose +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $@
+	$(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $@
 
 #########################################################################################
 # include build/project specific makefrags made from the generator

--- a/variables.mk
+++ b/variables.mk
@@ -147,7 +147,7 @@ output_dir=$(sim_dir)/output/$(long_name)
 # helper variables to run binaries
 #########################################################################################
 BINARY ?=
-SIM_FLAGS ?= +verbose +max-cycles=$(timeout_cycles)
+SIM_FLAGS ?= +max-cycles=$(timeout_cycles)
 sim_out_name = $(notdir $(basename $(BINARY))).$(long_name)
 
 #########################################################################################

--- a/variables.mk
+++ b/variables.mk
@@ -147,7 +147,7 @@ output_dir=$(sim_dir)/output/$(long_name)
 # helper variables to run binaries
 #########################################################################################
 BINARY ?=
-SIM_FLAGS ?= +verbose
+SIM_FLAGS ?= +verbose +max-cycles=$(timeout_cycles)
 sim_out_name = $(notdir $(basename $(BINARY))).$(long_name)
 
 #########################################################################################


### PR DESCRIPTION
Have the simulation rules share the `SIM_FLAGS` variable so that people can override them if they want.