### PR TITLE
MultiRoCC Support

### DIFF
--- a/generators/example/src/main/scala/ConfigMixins.scala
+++ b/generators/example/src/main/scala/ConfigMixins.scala
@@ -133,12 +133,12 @@ class WithMultiRoCC extends Config((site, here, up) => {
  * For ex:
  *   Core 0, 1, 2, 3 have been defined earlier
  *     with hartIds of 0, 1, 2, 3 respectively
- *   And you call WithMultiRoCCHwacha(Seq(0,1))
+ *   And you call WithMultiRoCCHwacha(0,1)
  *   Then Core 0 and 1 will get a Hwacha
  *
- * @param harts Seq of harts to specify which will get a Hwacha
+ * @param harts harts to specify which will get a Hwacha
  */
-class WithMultiRoCCHwacha(harts: Seq[Int]) extends Config((site, here, up) => {
+class WithMultiRoCCHwacha(harts: Int*) extends Config((site, here, up) => {
   case MultiRoCCKey => {
     require(harts.max <= ((up(RocketTilesKey, site).length + up(BoomTilesKey, site).length) - 1))
     up(MultiRoCCKey, site) ++ harts.distinct.map{ i =>

--- a/generators/example/src/main/scala/Configs.scala
+++ b/generators/example/src/main/scala/Configs.scala
@@ -220,7 +220,7 @@ class DualCoreBoomAndOneHwachaRocketConfig extends Config(
   new WithNormalBoomAndRocketTop ++
   new WithBootROM ++
   new WithMultiRoCC ++
-  new WithMultiRoCCHwacha(Seq(0)) ++ // put Hwacha just on hart0 which was renumbered to Rocket
+  new WithMultiRoCCHwacha(0) ++ // put Hwacha just on hart0 which was renumbered to Rocket
   new boom.system.WithRenumberHarts ++
   new hwacha.DefaultHwachaConfig ++
   new boom.common.WithRVC ++

--- a/generators/example/src/main/scala/Configs.scala
+++ b/generators/example/src/main/scala/Configs.scala
@@ -217,7 +217,7 @@ class DualCoreBoomAndOneRocketConfig extends Config(
   new freechips.rocketchip.system.BaseConfig)
 
 class DualCoreBoomAndOneHwachaRocketConfig extends Config(
-  new WithNormalBoomAndRocketTop ++
+  new WithNormalBoomRocketTop ++
   new WithBootROM ++
   new WithMultiRoCC ++
   new WithMultiRoCCHwacha(0) ++ // put Hwacha just on hart0 which was renumbered to Rocket

--- a/generators/example/src/main/scala/Configs.scala
+++ b/generators/example/src/main/scala/Configs.scala
@@ -216,6 +216,20 @@ class DualCoreBoomAndOneRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
 
+class DualCoreBoomAndOneHwachaRocketConfig extends Config(
+  new WithNormalBoomAndRocketTop ++
+  new WithBootROM ++
+  new WithMultiRoCC ++
+  new WithMultiRoCCHwacha(Seq(0)) ++ // put Hwacha just on hart0 which was renumbered to Rocket
+  new boom.system.WithRenumberHarts ++
+  new hwacha.DefaultHwachaConfig ++
+  new boom.common.WithRVC ++
+  new boom.common.DefaultBoomConfig ++
+  new boom.system.WithNBoomCores(2) ++
+  new freechips.rocketchip.subsystem.WithoutTLMonitors ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new freechips.rocketchip.system.BaseConfig)
+
 class RV32BoomAndRocketConfig extends Config(
   new WithNormalBoomRocketTop ++
   new WithBootROM ++


### PR DESCRIPTION
Based on #92 so wait until that is merged.

Allow for different RoCC accelerators to be attached to different harts. In this case, this is only for Hwacha but this can be used for other RoCC accelerators (Systolic Array).

Credit for initial work: @a0u @alonamid 