### PR TITLE
have boom depend on testchipip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val hwacha = (project in file ("generators/hwacha"))
   .dependsOn(rebarrocketchip)
   .settings(commonSettings)
 
-lazy val boom = (project in file("generators/boom"))
+lazy val boom = conditionalDependsOn(project in file("generators/boom"))
   .dependsOn(rebarrocketchip)
   .settings(commonSettings)
 


### PR DESCRIPTION
Have BOOM now depend on `testchipip` so that BOOM and can do TSI based bringup.

Needed for https://github.com/riscv-boom/riscv-boom/pull/283